### PR TITLE
Oncall load restrictions

### DIFF
--- a/calendar.go
+++ b/calendar.go
@@ -65,7 +65,7 @@ func getOncallMonthRestrictions(srv *calendar.Service, month time.Time) map[stri
 		res[person.Code] = &Restriction{0, 0}
 	}
 
-	if *Unrestrict == true {
+	if *flagUnrestrict {
 		// recast the schedule from scratch, so return all zeeeeeeeroes.
 		return res
 	}
@@ -93,7 +93,7 @@ func getOncallMonthRestrictions(srv *calendar.Service, month time.Time) map[stri
 		// 	fmt.Printf("Day: %d/%d Victim: %s WE: %t\n", day+1, weekday, oncall.Victim, isWeekend(firstday.AddDate(0, 0, day)))
 		// }
 	}
-	if *Verbose == true {
+	if *flagVerbose {
 		fmt.Printf("Oncall restrictions for %s %d:\n", month.Month(), month.Year())
 		for v, r := range res {
 			fmt.Printf("Oncaller: %s Days: %d WE: %d\n", v, r.DaysBooked, r.WeekendsBooked)
@@ -186,7 +186,7 @@ func setOncallByDay(srv *calendar.Service, day time.Time, victim oncallPerson) b
 	existing := getOncallByDay(srv, day)
 	if existing.Victim == oncall || existing.Fixed == true {
 		// Nothing to do except increment their load counter if we reset it
-		if *Unrestrict == true && existing.Fixed == false {
+		if *flagUnrestrict == true && existing.Fixed == false {
 			restrictions.Detail[victim.Code].DaysBooked++
 			if isWeekend(day) {
 				restrictions.Detail[victim.Code].WeekendsBooked++
@@ -219,13 +219,13 @@ func setOncallByDay(srv *calendar.Service, day time.Time, victim oncallPerson) b
 				eventAttendees := makeAttendees([]oncallPerson{victim})
 				event.Attendees = eventAttendees
 				event.Summary = fmt.Sprintf("%s onduty", oncall)
-				if *DryRun == false {
+				if *flagDryRun == false {
 					_, err := srv.Events.Update(config.OncallCalendar, event.Id, event).Do()
 					if err != nil {
 						log.Fatalf("Event update failed: %s\n", err)
 					}
 				}
-				if *Verbose == true {
+				if *flagVerbose {
 					fmt.Printf("%s is now oncall on %s (was %s)\n", victim.Code,
 						day.Format("2006-01-02"),
 						existing.Victim)
@@ -242,7 +242,7 @@ func setOncallByDay(srv *calendar.Service, day time.Time, victim oncallPerson) b
 			Start:     &calendar.EventDateTime{Date: starttime.Format("2006-01-02")},
 			End:       &calendar.EventDateTime{Date: starttime.AddDate(0, 0, 1).Format("2006-01-02")},
 		}
-		if *DryRun == false {
+		if *flagDryRun == false {
 			_, err := srv.Events.Insert(config.OncallCalendar, &newEvent).Do()
 			if err != nil {
 				fmt.Println(err)

--- a/calendar.go
+++ b/calendar.go
@@ -74,14 +74,19 @@ func getOncallMonthRestrictions(srv *calendar.Service, month time.Time) map[stri
 	// why does this work? because day 0 of a month is the last day of month-1!
 	daysinmonth := time.Date(month.Year(), month.Month()+1, 0, 0, 0, 0, 0, time.Local).Day()
 	for day := 0; day < daysinmonth; day++ {
-		oncall := getOncallByDay(srv, firstday.AddDate(0, 0, day))
+		nextday := firstday.AddDate(0, 0, day)
+		oncall := getOncallByDay(srv, nextday)
 		if oncall.Victim == "" {
 			continue
 		}
 
 		res[oncall.Victim].DaysBooked++
-		if isWeekend(firstday.AddDate(0, 0, day)) {
+		if isWeekend(nextday) {
 			res[oncall.Victim].WeekendsBooked++
+			// if day 1 is a Sunday, add 2 to avoid off-by-one errors later on...
+			if nextday.Weekday() == 0 && nextday.Day() == 1 {
+				res[oncall.Victim].WeekendsBooked++
+			}
 		}
 		// if *Verbose {
 		// 	fmt.Printf("Day: %d/%d Victim: %s WE: %t\n", day+1, weekday, oncall.Victim, isWeekend(firstday.AddDate(0, 0, day)))

--- a/calendar.go
+++ b/calendar.go
@@ -25,6 +25,11 @@ type OncallDay struct {
 	Fixed  bool
 }
 
+type Restriction struct {
+	DaysBooked     int
+	WeekendsBooked int
+}
+
 // getClient uses a Context and Config to retrieve a Token
 // then generate a Client. It returns the generated Client.
 func getClient(ctx context.Context, config *oauth2.Config) *http.Client {
@@ -50,6 +55,45 @@ func getDayEvents(srv *calendar.Service, day time.Time) ([]*calendar.Event, erro
 		TimeMin(starttime.Format(time.RFC3339)).
 		OrderBy("startTime").Do()
 	return events.Items, err
+}
+
+func getOncallMonthRestrictions(srv *calendar.Service, month time.Time) map[string]*Restriction {
+	res := make(map[string]*Restriction)
+
+	for _, person := range config.Oncallers {
+		res[person.Code] = &Restriction{0, 0}
+	}
+
+	if *Unrestrict {
+		// recast the schedule from scratch, so return all zeeeeeeeroes.
+		return res
+	}
+
+	// FIXME horrible time zone handling here - needs a general solution
+	firstday := time.Date(month.Year(), month.Month(), 1, 3, 0, 0, 0, time.Local)
+	// why does this work? because day 0 of a month is the last day of month-1!
+	daysinmonth := time.Date(month.Year(), month.Month()+1, 0, 0, 0, 0, 0, time.Local).Day()
+	for day := 0; day < daysinmonth; day++ {
+		oncall := getOncallByDay(srv, firstday.AddDate(0, 0, day))
+		if oncall.Victim == "" {
+			continue
+		}
+
+		res[oncall.Victim].DaysBooked++
+		if isWeekend(firstday.AddDate(0, 0, day)) {
+			res[oncall.Victim].WeekendsBooked++
+		}
+		// if *Verbose {
+		// 	fmt.Printf("Day: %d/%d Victim: %s WE: %t\n", day+1, weekday, oncall.Victim, isWeekend(firstday.AddDate(0, 0, day)))
+		// }
+	}
+	if *Verbose {
+		fmt.Printf("Oncall restrictions for %s %d:\n", month.Month(), month.Year())
+		for v, r := range res {
+			fmt.Printf("Oncaller: %s Days: %d WE: %d\n", v, r.DaysBooked, r.WeekendsBooked)
+		}
+	}
+	return res
 }
 
 // Find the person in the oncall calendar for a given day.
@@ -107,6 +151,13 @@ func getTokenFromWeb(config *oauth2.Config) *oauth2.Token {
 	return tok
 }
 
+func isWeekend(day time.Time) bool {
+	if day.Weekday() == 0 || day.Weekday() == 6 {
+		return true
+	}
+	return false
+}
+
 func makeAttendees(people []oncallPerson) []*calendar.EventAttendee {
 	var attendees []*calendar.EventAttendee
 	for _, person := range people {
@@ -155,9 +206,11 @@ func setOncallByDay(srv *calendar.Service, day time.Time, victim oncallPerson) b
 				eventAttendees := makeAttendees([]oncallPerson{victim})
 				event.Attendees = eventAttendees
 				event.Summary = fmt.Sprintf("%s onduty", oncall)
-				_, err := srv.Events.Update(config.OncallCalendar, event.Id, event).Do()
-				if err != nil {
-					log.Fatalf("Event update failed: %s\n", err)
+				if *DryRun == false {
+					_, err := srv.Events.Update(config.OncallCalendar, event.Id, event).Do()
+					if err != nil {
+						log.Fatalf("Event update failed: %s\n", err)
+					}
 				}
 				if *Verbose == true {
 					fmt.Printf("%s is now oncall on %s (was %s)\n", victim.Code,
@@ -176,10 +229,24 @@ func setOncallByDay(srv *calendar.Service, day time.Time, victim oncallPerson) b
 			Start:     &calendar.EventDateTime{Date: starttime.Format("2006-01-02")},
 			End:       &calendar.EventDateTime{Date: starttime.AddDate(0, 0, 1).Format("2006-01-02")},
 		}
-		_, err := srv.Events.Insert(config.OncallCalendar, &newEvent).Do()
-		if err != nil {
-			fmt.Println(err)
-			return false
+		if *DryRun == false {
+			_, err := srv.Events.Insert(config.OncallCalendar, &newEvent).Do()
+			if err != nil {
+				fmt.Println(err)
+				return false
+			}
+		}
+	}
+	// Increment the load counter..
+	restrictions.Detail[victim.Code].DaysBooked++
+	if isWeekend(day) {
+		restrictions.Detail[victim.Code].WeekendsBooked++
+	}
+	// And decrement it if it was rewritten.
+	if rewritten {
+		restrictions.Detail[existing.Victim].DaysBooked--
+		if isWeekend(day) {
+			restrictions.Detail[existing.Victim].WeekendsBooked--
 		}
 	}
 	return true

--- a/notify.go
+++ b/notify.go
@@ -19,6 +19,7 @@ type Mail struct {
 // Send the oncall notification mail.
 func doNotify(victim string, when string) error {
 	address := ""
+	slackID := ""
 	var err error
 	var mail Mail
 	emergency := false
@@ -61,6 +62,7 @@ func doNotify(victim string, when string) error {
 	for _, c := range config.Oncallers {
 		if c.Code == victim {
 			address = c.Email
+			slackID = c.SlackID
 		}
 	}
 	if address != "" {
@@ -71,6 +73,10 @@ func doNotify(victim string, when string) error {
 	}
 	if config.MailServer == "" {
 		config.MailServer = "localhost:25"
+	}
+	if config.SlackKey != "" {
+		slackMessage := fmt.Sprintf("Hello %s! This is to remind you that you're on duty today.", victim)
+		notifySlack(slackID, slackMessage)
 	}
 	err = mailSend(mail, config.MailServer)
 	if err != nil {

--- a/notify.go
+++ b/notify.go
@@ -102,7 +102,7 @@ func mailSend(mail Mail, server string) error {
 	fulltext := strings.Join(headers, "\r\n") + "\r\n\r\n"
 	// And add the body
 	fulltext += strings.Join(mail.Body, "\r\n") + "\r\n"
-	if *Verbose == true {
+	if *flagDebug {
 		fmt.Printf("Sending mail:\n%s", fulltext)
 	}
 	err := smtp.SendMail(server,

--- a/rotator.yaml
+++ b/rotator.yaml
@@ -1,10 +1,15 @@
 ---
 secretfile: client_secret.json
 generatedays: 30
+maxdayspermonth: 10
+maxweekendspermonth: 1
+shadowoncaller: nn
 availabilitycalendar: replacethis@group.calendar.google.com
 oncallcalendar: replacethis@group.calendar.google.com
 mailserver: mail.example.com:25
 mailsender: admin@example.com
+slackkey: my_slack_api_key
+slackchannel: my_slack_channel_id
 
 awaywords:
   - away

--- a/slack.go
+++ b/slack.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/nlopes/slack"
+)
+
+func notifySlack(message string, destination string) {
+
+	slackAPI := slack.New(config.SlackKey)
+	params := slack.PostMessageParameters{}
+	/* attach := slack.Attachment{
+			Pretext: "my pretext",
+			Text:    "some text",
+		}
+	  params.Attachments = []slack.Attachment{attach} */
+	channel := config.SlackChannel
+	if destination != "" {
+		channel = destination
+	}
+
+	c, timestamp, err := slackAPI.PostMessage(channel, message, params)
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return
+	}
+	fmt.Printf("Message sent to channel %s at %s", c, timestamp)
+}


### PR DESCRIPTION
Adds new config options:

* maxdayspermonth: Maximum days total oncall per month per oncaller (including weekends)
* maxweekendspermonth: Maximum weekend days per month per oncaller
* shadowoncaller: A code which will be "on call" when nobody is available. "Oops, need more people!"

TODO:
* Refactor the availability checking stuff, as it's making too many repeated API calls = slow.
* Lint fixes
* Rewrite to read/write the whole period at once rather than one day at a time. The latter is neat when everything is simple, but it gets messy when it's not simple any more.